### PR TITLE
Run gtm in background with rate limit of 1/s

### DIFF
--- a/src/io/edgeg/gtm/intellij/GTMBackgroundRunner.java
+++ b/src/io/edgeg/gtm/intellij/GTMBackgroundRunner.java
@@ -1,0 +1,73 @@
+package io.edgeg.gtm.intellij;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.concurrent.Semaphore;
+
+public class GTMBackgroundRunner extends Task.Backgroundable {
+    private static final Long RECORD_MIN_UNIT = 1000L; // 1 second
+    private static final Long RECORD_MIN_THRESHOLD = 30000L; // 30 seconds
+    private Project project;
+    private Semaphore semaphore = new Semaphore(1);
+    private String QueuedPath = "";
+    private String LastPath = "";
+    private Boolean Running = false;
+    private Long lastRecordTime = null;
+
+
+    GTMBackgroundRunner(Project project) {
+        super(project, "GTM Record");
+        this.project = project;
+    }
+
+    public void run(@NotNull ProgressIndicator indicator) {
+        do {
+            Long startTime = System.currentTimeMillis();
+            String path = QueuedPath;
+            QueuedPath = "";
+            semaphore.release();
+            GTMRecord.record(path, project);
+            Long elapsedTime = System.currentTimeMillis() - startTime;
+            if (elapsedTime < RECORD_MIN_UNIT) {
+                try {
+                    Thread.sleep(RECORD_MIN_UNIT - elapsedTime);
+                } catch (InterruptedException e) {
+                    GTMConfig.LOG.error(e);
+                }
+            }
+            try {
+                semaphore.acquire();
+            } catch (InterruptedException e) {
+                GTMConfig.LOG.error(e);
+            }
+        } while (!QueuedPath.isEmpty());
+        Running = false;
+        semaphore.release();
+    }
+    void record(String path) {
+        Long currentTime = System.currentTimeMillis();
+        if (Objects.equals(LastPath, path) && lastRecordTime != null && currentTime - lastRecordTime <= RECORD_MIN_THRESHOLD) {
+            return;
+        }
+        lastRecordTime = currentTime;
+
+        try {
+            semaphore.acquire();
+            QueuedPath = path;
+            LastPath = path;
+            if (!Running) {
+                Running = true;
+                ProgressManager.getInstance().run(this);
+            } else {
+                semaphore.release();
+            }
+        } catch (InterruptedException e) {
+            GTMConfig.LOG.error(e);
+        }
+    }
+}

--- a/src/io/edgeg/gtm/intellij/GTMEditorMouseListener.java
+++ b/src/io/edgeg/gtm/intellij/GTMEditorMouseListener.java
@@ -3,6 +3,7 @@ package io.edgeg.gtm.intellij;
 import com.intellij.openapi.editor.event.EditorMouseEvent;
 import com.intellij.openapi.editor.event.EditorMouseListener;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 
 class GTMEditorMouseListener implements EditorMouseListener {
@@ -12,7 +13,10 @@ class GTMEditorMouseListener implements EditorMouseListener {
         final FileDocumentManager instance = FileDocumentManager.getInstance();
         final VirtualFile file = instance.getFile(editorMouseEvent.getEditor().getDocument());
         if (file != null) {
-            GTMRecord.record(file.getPath(), editorMouseEvent.getEditor().getProject());
+            Project proj = editorMouseEvent.getEditor().getProject();
+            if (proj != null) {
+                proj.getComponent(GTMProject.class).getGTMBackgroundRunner().record(file.getPath());
+            }
         }
     }
 

--- a/src/io/edgeg/gtm/intellij/GTMProject.java
+++ b/src/io/edgeg/gtm/intellij/GTMProject.java
@@ -14,6 +14,7 @@ import static com.intellij.openapi.ui.MessageType.WARNING;
 
 public class GTMProject extends AbstractProjectComponent {
     private GTMStatusWidget myStatusWidget;
+    private GTMBackgroundRunner myBackgroundRunner;
 
     public GTMProject(@NotNull Project project) {
         super(project);
@@ -22,6 +23,11 @@ public class GTMProject extends AbstractProjectComponent {
     @Override
     public void initComponent() {
         myStatusWidget = GTMStatusWidget.create(myProject);
+        myBackgroundRunner = new GTMBackgroundRunner(myProject);
+    }
+
+    GTMBackgroundRunner getGTMBackgroundRunner() {
+        return myBackgroundRunner;
     }
 
     @Override

--- a/src/io/edgeg/gtm/intellij/GTMRecord.java
+++ b/src/io/edgeg/gtm/intellij/GTMRecord.java
@@ -14,15 +14,10 @@ import java.util.Objects;
 
 class GTMRecord {
     private static final String GTM_VER_REQ = ">= 1.2.5";
-
-    private static final Long RECORD_MIN_THRESHOLD = 30000L; // 30 seconds
     private static final String RECORD_COMMAND = "record";
     private static final String STATUS_OPTION = "--status";
     private static final String VERIFY_COMMAND = "verify";
-
     private static String gtmExePath = null;
-    private static String lastRecordPath = null;
-    private static Long lastRecordTime = null;
 
     static Boolean gtmExeFound = false;
     static Boolean gtmVersionOK = true;
@@ -35,14 +30,6 @@ class GTMRecord {
             status = "Error!";
         } else {
             try {
-                Long currentTime = System.currentTimeMillis();
-                if (Objects.equals(lastRecordPath, path)) {
-                    if (lastRecordTime != null && currentTime - lastRecordTime <= RECORD_MIN_THRESHOLD) {
-                        return;
-                    }
-                }
-                lastRecordPath = path;
-                lastRecordTime = currentTime;
                 if (cfg.statusEnabled) {
 
 //                    GTMConfig.LOG.info(

--- a/src/io/edgeg/gtm/intellij/GTMVisibleAreaListener.java
+++ b/src/io/edgeg/gtm/intellij/GTMVisibleAreaListener.java
@@ -3,6 +3,7 @@ package io.edgeg.gtm.intellij;
 import com.intellij.openapi.editor.event.VisibleAreaEvent;
 import com.intellij.openapi.editor.event.VisibleAreaListener;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 
 class GTMVisibleAreaListener implements VisibleAreaListener {
@@ -12,7 +13,10 @@ class GTMVisibleAreaListener implements VisibleAreaListener {
         final FileDocumentManager instance = FileDocumentManager.getInstance();
         final VirtualFile file = instance.getFile(visibleAreaEvent.getEditor().getDocument());
         if (file != null) {
-            GTMRecord.record(file.getPath(), visibleAreaEvent.getEditor().getProject());
+            Project proj = visibleAreaEvent.getEditor().getProject();
+            if (proj != null) {
+                proj.getComponent(GTMProject.class).getGTMBackgroundRunner().record(file.getPath());
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes issues with lagging tab switching. With status enabled UI was locked till end of GTM execution.