### PR TITLE
Subscribe to widget connection after install

### DIFF
--- a/src/io/edgeg/gtm/intellij/GTMStatusWidget.java
+++ b/src/io/edgeg/gtm/intellij/GTMStatusWidget.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.StatusBarWidget;
 import com.intellij.openapi.wm.impl.status.EditorBasedWidget;
 import com.intellij.util.Consumer;
@@ -26,9 +27,6 @@ public class GTMStatusWidget extends EditorBasedWidget implements StatusBarWidge
 
     private GTMStatusWidget(@NotNull Project project) {
         super(project);
-
-        myConnection.subscribe(UISettingsListener.TOPIC, uiSettings -> runUpdateLater());
-
     }
 
     private void runUpdateLater() {
@@ -121,6 +119,12 @@ public class GTMStatusWidget extends EditorBasedWidget implements StatusBarWidge
     @Override
     public Consumer<MouseEvent> getClickConsumer() {
         return mouseEvent -> runUpdate();
+    }
+
+    @Override
+    public void install(@NotNull StatusBar statusBar) {
+        super.install(statusBar);
+        myConnection.subscribe(UISettingsListener.TOPIC, uiSettings -> runUpdateLater());
     }
 
     void installed() {


### PR DESCRIPTION
This fixes a crash in 193.5233.102 where using `myConnection` in constructor of `GTMStatusWidget` would cause a null pointer exception.
Subscribing in `install()` ensures that the connection is initialized first.

I tested and verified with IntelliJ IDEA 2019.3.